### PR TITLE
fix docker ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.turbo
+build
+node_modules

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@v2
         with:
-          context: ./apps/client
           push: true
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/scoretrak-client:${{ github.sha }}


### PR DESCRIPTION
Update docker ci to work with pnpm and monorepo as the current dockerfile breaks at yarn build.
There were many useless and endless typescript errors were thrown.