### PR TITLE
implement policy context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import CssBaseline from "@material-ui/core/CssBaseline";
 import {gRPCClients} from "./grpc/gRPCClients";
 import Dashboard from "./components/Dashboard/Dashboard";
 import {SnackbarProvider} from "notistack";
+import {PolicyProvider} from "./contexts/PolicyContext";
 
 function App() {
   useEffect(() => {
@@ -43,9 +44,11 @@ function App() {
           horizontal: 'right',
         }} dense preventDuplicate>
         <CssBaseline />
-          <Router>
-            <Dashboard theme={{isDarkTheme, setIsDarkTheme}}  gRPCClients={gRPCClients} />
-          </Router>
+            <Router>
+              <PolicyProvider>
+                <Dashboard theme={{isDarkTheme, setIsDarkTheme}}  gRPCClients={gRPCClients} />
+              </PolicyProvider>
+            </Router>
         </SnackbarProvider>
       </ThemeProvider>
     </div>

--- a/src/components/ScoreBoard/ScoreBoard.tsx
+++ b/src/components/ScoreBoard/ScoreBoard.tsx
@@ -10,13 +10,13 @@ import Button from '@material-ui/core/Button';
 import FullscreenExitIcon from '@material-ui/icons/FullscreenExit';
 import {makeStyles} from "@material-ui/core/styles";
 import {GRPCClients} from "../../grpc/gRPCClients";
-import {Policy} from "../../lib/scoretrakapis/scoretrak/policy/v1/policy_pb";
 import {ThemeState, SimpleReport, Severity} from "../../types/types";
 import {FullScreenHandle} from "react-full-screen";
 import {GetRequest, GetResponse} from "../../lib/scoretrakapis/scoretrak/report/v1/report_pb";
 import {Role, token} from "../../grpc/token/token";
 import clsx from "clsx";
 import Ranks from "./Ranks";
+import {usePolicy} from "../../contexts/PolicyContext";
 
 const useStyles = makeStyles((theme) => ({
     hidden: { opacity: 0.1, transition: "opacity 0.2s linear"},
@@ -37,7 +37,6 @@ const useStyles = makeStyles((theme) => ({
 
 type ScoreBoardProps = {
     gRPCClients: GRPCClients,
-    currentPolicy: Policy.AsObject,
     theme: ThemeState,
     setTitle: React.Dispatch<React.SetStateAction<string>>;
     handleFullScreen: FullScreenHandle
@@ -46,6 +45,7 @@ type ScoreBoardProps = {
 
 
 export default function ScoreBoard(props : ScoreBoardProps) {
+    const policy = usePolicy()
     const [report, setReport] = useState<SimpleReport | undefined>(undefined);
     const [visible, setFade] = React.useState<boolean>(false);
     const classes = useStyles();
@@ -87,13 +87,13 @@ export default function ScoreBoard(props : ScoreBoardProps) {
             <Box className={classes.alignItemsAndJustifyContent} height="100%" width="100%"  >
                 { report && report.Round !== 0 ?
                     <Box m="auto" style={{height: handleFullScreen.active ? '100vh' : '85vh', width: '100%'}}>
-                        { (props.currentPolicy.showPoints?.value || token.getCurrentRole() === Role.Black) &&
+                        { policy && (policy.showPoints?.value || token.getCurrentRole() === Role.Black) &&
                         <Route exact path='/ranks' render={() => (
                             <Ranks isDarkTheme={props.theme.isDarkTheme} report={report}/>
                         )}/>
                         }
                         <Route exact path='/' render={() => (
-                            <Status currentPolicy={props.currentPolicy} isDarkTheme={props.theme.isDarkTheme} report={report}/>
+                            <Status isDarkTheme={props.theme.isDarkTheme} report={report}/>
                         )} />
                         <Route exact path='/details' render={() => (
                             <Details isDarkTheme={props.theme.isDarkTheme} report={report} gRPCClients={props.gRPCClients} genericEnqueue={props.genericEnqueue}/>

--- a/src/components/ScoreBoard/Status.tsx
+++ b/src/components/ScoreBoard/Status.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect} from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableFooter from '@material-ui/core/TableFooter';
@@ -11,9 +10,9 @@ import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
-import {SimpleCheck, SimpleReport, SimpleService} from "../../types/types";
-import {Policy} from "../../lib/scoretrakapis/scoretrak/policy/v1/policy_pb";
+import {SimpleReport, SimpleService} from "../../types/types";
 import {token} from "../../grpc/token/token";
+import {usePolicy} from "../../contexts/PolicyContext";
 
 
 const useStyles = makeStyles({
@@ -30,13 +29,13 @@ const useStyles = makeStyles({
 type RanksProps = {
     report: SimpleReport
     isDarkTheme: boolean
-    currentPolicy: Policy.AsObject,
 }
 
 export default function Status(props: RanksProps) {
     useEffect(() => {
         document.title = "Status"
     }, []);
+    const policy = usePolicy()
     const classes = useStyles();
     const [rowPage, setRowPage] = React.useState<number>(0);
     const [rowsPerPage, setRowsPerPage] = React.useState<number>(25);
@@ -233,7 +232,7 @@ export default function Status(props: RanksProps) {
                                                   control={<Switch checked={dense} onChange={toggleChangeDense} />}
                                                   label="Dense padding"
                                 />
-                                { (token.isAValidToken() || props.currentPolicy.showAddresses?.value) &&
+                                { policy && (token.isAValidToken() || policy.showAddresses?.value) &&
                                 <FormControlLabel className={classes.tableNavigator}
                                                   control={<Switch checked={hideAddresses} onChange={toggleHideAddresses} />}
                                                   label={"Hide Addresses"}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -52,6 +52,7 @@ import {HostGroup} from "../../lib/scoretrakapis/scoretrak/host_group/v1/host_gr
 import {ServiceGroup} from "../../lib/scoretrakapis/scoretrak/service_group/v1/service_group_pb";
 import {Service} from "../../lib/scoretrakapis/scoretrak/service/v1/service_pb";
 import {Property} from "../../lib/scoretrakapis/scoretrak/property/v1/property_pb";
+import {usePolicy} from "../../contexts/PolicyContext";
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -90,7 +91,8 @@ const Transition = React.forwardRef(function Transition(props: TransitionProps &
 });
 
 
-export default function Settings(props: SetupProps & {currentPolicy: Policy.AsObject}) {
+export default function Settings(props: SetupProps ) {
+    const policy = usePolicy()
     const classes = useStyles();
     const setTitle = props.setTitle
     setTitle("Settings")
@@ -409,65 +411,73 @@ export default function Settings(props: SetupProps & {currentPolicy: Policy.AsOb
                         </AccordionDetails>
                     </Accordion>
 
-                    <Accordion expanded={expanded === 'panelPolicy'} onChange={handleChange('panelPolicy')}>
-                        <AccordionSummary
-                            expandIcon={<ExpandMoreIcon />}
-                            aria-controls="panelPolicybh-content"
-                            id="panelPolicybh-header"
-                        >
-                            <Typography className={classes.heading}>Policy</Typography>
-                            <Typography className={classes.secondaryHeading}>Configure policies for allowing/disallowing resources</Typography>
+                    { policy &&
+                        <Accordion expanded={expanded === 'panelPolicy'} onChange={handleChange('panelPolicy')}>
+                            <AccordionSummary
+                                expandIcon={<ExpandMoreIcon/>}
+                                aria-controls="panelPolicybh-content"
+                                id="panelPolicybh-header"
+                            >
+                                <Typography className={classes.heading}>Policy</Typography>
+                                <Typography className={classes.secondaryHeading}>Configure policies for
+                                    allowing/disallowing resources</Typography>
 
-                        </AccordionSummary>
-                        <AccordionDetails>
-                            <Box p={1} m={1} bgcolor="background.paper">
-                            <FormControlLabel
-                                control={
-                                    <Switch checked={props.currentPolicy.allowUnauthenticatedUsers?.value} onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                        handleSetPolicy(new Policy().setAllowUnauthenticatedUsers(new BoolValue().setValue(e.target.checked)))
-                                    }} value="allow_unauthenticated_users" />
-                                }
-                                label="Allow unauthenticated users to see scoreboard"
-                            />
-                            <br />
-                            <FormControlLabel
-                                control={
-                                    <Switch checked={props.currentPolicy.allowChangingUsernamesAndPasswords?.value} onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                        handleSetPolicy(new Policy().setAllowChangingUsernamesAndPasswords(new BoolValue().setValue(e.target.checked)))
-                                    }} value="allow_changing_usernames_and_passwords" />
-                                }
-                                label="Allow users to change usernames and passwords"
-                            />
-                                <br />
-                            <FormControlLabel
-                                control={
-                                    <Switch checked={props.currentPolicy.showPoints?.value} onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                        handleSetPolicy(new Policy().setShowPoints(new BoolValue().setValue(e.target.checked)))
-                                    }} value="allow_to_see_points" />
-                                }
-                                label="Allow users to see other teams' points"
-                            />
-                                <br />
-                            <FormControlLabel
-                                control={
-                                    <Switch checked={props.currentPolicy.showAddresses?.value} onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                        handleSetPolicy(new Policy().setShowAddresses(new BoolValue().setValue(e.target.checked)))
-                                    }} value="show_addresses" />
-                                }
-                                label="Allow users to see other teams' addresses"
-                            />
-                                <br />
-                            <FormControlLabel
-                                control={
-                                    <Switch checked={props.currentPolicy.allowRedTeamLaunchingServiceTestsManually?.value} onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                        handleSetPolicy(new Policy().setAllowRedTeamLaunchingServiceTestsManually(new BoolValue().setValue(e.target.checked)))
-                                    }} value="allow_red_team_launching_service_tests_manually" />
-                                }
-                                label="Allow Red Team to manually launch service tests(Only applies to a parrent team)"
-                            />
-                            </Box>
-                        </AccordionDetails>
-                    </Accordion>
+                            </AccordionSummary>
+                            <AccordionDetails>
+                                <Box p={1} m={1} bgcolor="background.paper">
+                                    <FormControlLabel
+                                        control={
+                                            <Switch checked={policy.allowUnauthenticatedUsers?.value}
+                                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                                        handleSetPolicy(new Policy().setAllowUnauthenticatedUsers(new BoolValue().setValue(e.target.checked)))
+                                                    }} value="allow_unauthenticated_users"/>
+                                        }
+                                        label="Allow unauthenticated users to see scoreboard"
+                                    />
+                                    <br/>
+                                    <FormControlLabel
+                                        control={
+                                            <Switch checked={policy.allowChangingUsernamesAndPasswords?.value}
+                                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                                        handleSetPolicy(new Policy().setAllowChangingUsernamesAndPasswords(new BoolValue().setValue(e.target.checked)))
+                                                    }} value="allow_changing_usernames_and_passwords"/>
+                                        }
+                                        label="Allow users to change usernames and passwords"
+                                    />
+                                    <br/>
+                                    <FormControlLabel
+                                        control={
+                                            <Switch checked={policy.showPoints?.value}
+                                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                                        handleSetPolicy(new Policy().setShowPoints(new BoolValue().setValue(e.target.checked)))
+                                                    }} value="allow_to_see_points"/>
+                                        }
+                                        label="Allow users to see other teams' points"
+                                    />
+                                    <br/>
+                                    <FormControlLabel
+                                        control={
+                                            <Switch checked={policy.showAddresses?.value}
+                                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                                        handleSetPolicy(new Policy().setShowAddresses(new BoolValue().setValue(e.target.checked)))
+                                                    }} value="show_addresses"/>
+                                        }
+                                        label="Allow users to see other teams' addresses"
+                                    />
+                                    <br/>
+                                    <FormControlLabel
+                                        control={
+                                            <Switch checked={policy.allowRedTeamLaunchingServiceTestsManually?.value}
+                                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                                        handleSetPolicy(new Policy().setAllowRedTeamLaunchingServiceTestsManually(new BoolValue().setValue(e.target.checked)))
+                                                    }} value="allow_red_team_launching_service_tests_manually"/>
+                                        }
+                                        label="Allow Red Team to manually launch service tests(Only applies to a parrent team)"
+                                    />
+                                </Box>
+                            </AccordionDetails>
+                        </Accordion>
+                    }
 
                     <Accordion expanded={expanded === 'panelStaticConfig'} onChange={handleChange('panelStaticConfig')}>
                         <AccordionSummary

--- a/src/components/SnackbarDismissButton.tsx
+++ b/src/components/SnackbarDismissButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import {Button} from "@material-ui/core";
+import {useSnackbar} from "notistack";
+
+
+export function SnackbarDismissButton(key: string) {
+    const {closeSnackbar} = useSnackbar()
+
+    return (
+        <>
+            <Button variant={'outlined'} onClick={() => closeSnackbar(key)}>
+                Dismiss
+            </Button>
+        </>
+    )
+}

--- a/src/contexts/PolicyContext.tsx
+++ b/src/contexts/PolicyContext.tsx
@@ -1,0 +1,52 @@
+import React, {createContext, useContext, useEffect, useState} from "react";
+import {GetRequest, Policy} from "../lib/scoretrakapis/scoretrak/policy/v1/policy_pb";
+import {gRPCClients} from "../grpc/gRPCClients";
+import grpcWeb from "grpc-web"
+import {useSnackbar} from "notistack";
+import {Severity} from "../types/types";
+import {token} from "../grpc/token/token";
+import {useHistory} from "react-router-dom";
+import {SnackbarDismissButton} from "../components/SnackbarDismissButton";
+
+const PolicyContext = createContext<Policy.AsObject | undefined>(undefined)
+
+export function usePolicy() {
+    return useContext(PolicyContext)
+}
+
+// @ts-ignore
+export function PolicyProvider({ children }) {
+    const { enqueueSnackbar } = useSnackbar()
+    const history = useHistory()
+    const [policy, setPolicy] = useState<Policy.AsObject>()
+
+    useEffect(() => {
+        const streamRequest = new GetRequest()
+        const stream = gRPCClients.policyClient.get(streamRequest, {})
+
+        stream.on("error", (error: grpcWeb.RpcError) => {
+            if (error.code === 7 || error.code === 16){
+                enqueueSnackbar(`You are not authorized to perform this action. Please Log in`, { variant: Severity.Error, action: SnackbarDismissButton } )
+                token.logout()
+                history.push("/login");
+            } else {
+                enqueueSnackbar(`Encountered an error while fetching policy: ${error.message}. Error code: ${error.code}`, { variant: Severity.Error, action: SnackbarDismissButton })
+            }
+        })
+
+        stream.on("data", (response) => {
+            if (response.hasPolicy()) {
+                setPolicy(response.getPolicy()!.toObject())
+            }
+        })
+
+        return () => stream.cancel()
+    }, [])
+
+    return (
+        <PolicyContext.Provider value={policy}>
+            {children}
+        </PolicyContext.Provider>
+    )
+
+}


### PR DESCRIPTION
Create a policy context to share the policy object across any component without drilling them through the props. Tested locally to confirm all components using the context is grabbing the latest one after updating in the settings page